### PR TITLE
Fix Cloud Build: Docker permissions and npm start entry point

### DIFF
--- a/services/api-backend/Dockerfile
+++ b/services/api-backend/Dockerfile
@@ -9,11 +9,14 @@ RUN npm ci --only=production && npm cache clean --force
 # Copy application source
 COPY . .
 
+# Fix ownership for node user
+RUN chown -R node:node /app
+
 # Health port
 EXPOSE 3000
 
-# Run as non-root where possible
+# Run as non-root
 USER node
 
-# Use --import for ES modules tracing instead of --require
-CMD ["node", "--import", "./tracing.js", "server.js"]
+# Start with npm script to ensure proper environment
+CMD ["npm", "start"]

--- a/services/streaming-proxy/Dockerfile
+++ b/services/streaming-proxy/Dockerfile
@@ -9,7 +9,11 @@ RUN npm ci --only=production && npm cache clean --force
 # Copy application source
 COPY . .
 
+# Fix ownership for node user
+RUN chown -R node:node /app
+
 EXPOSE 3001
 USER node
-# Use --import for ES modules tracing instead of --require
-CMD ["node", "--import", "./tracing.js", "proxy-server.js"]
+
+# Start with npm script to ensure proper environment
+CMD ["npm", "start"]


### PR DESCRIPTION
**Root Cause Analysis:** Cloud Build failures for API backend and streaming proxy likely due to file permission issues and incorrect entry point handling.

**Key Fixes:**
1. **File Ownership**: Added `chown -R node:node /app` to ensure node user can access all files
2. **Entry Point**: Changed from direct `node --import ./tracing.js server.js` to `npm start`
   - npm start scripts already handle tracing correctly with `--require ./tracing.js`
   - Avoids ES modules/CommonJS complexity by using the tested npm scripts
   - Ensures proper environment setup

**Why This Should Work:**
- Web job already succeeds (nginx-based, no Node.js issues)
- API/streaming package.json scripts are tested and working locally
- File permission issues are common cause of Cloud Build failures
- npm start provides consistent environment vs direct node execution

**Expected Results:**
- All three Cloud Build jobs should succeed
- API and streaming containers should start properly
- Tracing should work correctly
- Issue #97 deployment pipeline requirements met

**Previous Attempts:**
- ✅ Fixed digest resolution (web job now succeeds)
- ✅ Fixed port configurations (8080→3000/3001)
- ❌ ES modules --import fix (didn't resolve the issue)
- 🔄 This fix: permissions + npm start (should resolve remaining issues)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author