### PR TITLE
Fix login authentication failure

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -70,10 +70,9 @@ class AuthService extends ChangeNotifier {
     try {
       await _auth0Service.login();
       // Note: login() will redirect, so code after this won't execute immediately
-    } catch (e) {
+    } finally {
       _isLoading.value = false;
       notifyListeners();
-      rethrow;
     }
   }
 
@@ -86,11 +85,9 @@ class AuthService extends ChangeNotifier {
       await _auth0Service.logout();
       _isAuthenticated.value = false;
       _currentUser = null;
-      notifyListeners();
-    } catch (e) {
+    } finally {
       _isLoading.value = false;
       notifyListeners();
-      rethrow;
     }
   }
 


### PR DESCRIPTION
Ensure `_isLoading` always resets after login and logout operations to prevent the app from getting stuck in a loading state.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a0aec16-13fb-417a-9610-4b178f4e689e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a0aec16-13fb-417a-9610-4b178f4e689e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use finally blocks in `AuthService.login` and `logout` to always reset `_isLoading` and notify listeners, removing catch/rethrow paths.
> 
> - **Auth Service (`lib/services/auth_service.dart`)**:
>   - **Control flow**: Replace `catch`/`rethrow` with `finally` in `login` and `logout` to always reset `_isLoading` and call `notifyListeners()`.
>   - **State updates**: Preserve logout side effects (`_isAuthenticated = false`, `_currentUser = null`) while ensuring loading state is cleared regardless of outcome.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ecf5e26bacf426afd5f912f20b077ff669ebbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->