### PR TITLE
Refactor auth service to use finally blocks

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -70,10 +70,9 @@ class AuthService extends ChangeNotifier {
     try {
       await _auth0Service.login();
       // Note: login() will redirect, so code after this won't execute immediately
-    } catch (e) {
+    } finally {
       _isLoading.value = false;
       notifyListeners();
-      rethrow;
     }
   }
 
@@ -86,11 +85,9 @@ class AuthService extends ChangeNotifier {
       await _auth0Service.logout();
       _isAuthenticated.value = false;
       _currentUser = null;
-      notifyListeners();
-    } catch (e) {
+    } finally {
       _isLoading.value = false;
       notifyListeners();
-      rethrow;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace try/catch with try/finally in `AuthService` `login` and `logout` so loading state and notifications always run.
> 
> - **Auth Service (`lib/services/auth_service.dart`)**:
>   - Replace `try/catch` with `try/finally` in `login` and `logout` to always reset `_isLoading` and call `notifyListeners()`.
>   - Remove `rethrow` paths; rely on `finally` for cleanup after `auth0Service.login()`/`logout()`.
>   - During `logout`, move listener notification/cleanup to `finally` after setting `_isAuthenticated` and `_currentUser`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ecf5e26bacf426afd5f912f20b077ff669ebbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->