### PR TITLE
ai(Rook): add repository dispatch trigger for Simon VPS cloudflared recovery

### DIFF
--- a/.github/workflows/recover-simon-vps-cloudflared.yml
+++ b/.github/workflows/recover-simon-vps-cloudflared.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: root
         type: string
+  repository_dispatch:
+    types:
+      - recover_simon_vps_cloudflared
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds repository_dispatch support to the Simon VPS cloudflared recovery workflow so it can be launched even when workflow_dispatch is not accepted by the remote workflow index.