### PR TITLE
ai(Rook): trigger Simon VPS cloudflared recovery on push

### DIFF
--- a/.github/workflows/recover-simon-vps-cloudflared.yml
+++ b/.github/workflows/recover-simon-vps-cloudflared.yml
@@ -1,6 +1,12 @@
 name: Recover Simon VPS Cloudflared
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/recover-simon-vps-cloudflared.yml
+      - deploy/simon-vps/**
   workflow_dispatch:
     inputs:
       host:


### PR DESCRIPTION
Adds a narrow push trigger so the Simon VPS cloudflared recovery workflow runs on merges that touch the recovery workflow or Simon deploy files.