### PR TITLE
feat(windows): restore installer build and release path

### DIFF
--- a/.github/commands/gemini-triage.toml
+++ b/.github/commands/gemini-triage.toml
@@ -2,7 +2,7 @@ description = "Triages an issue with Gemini CLI"
 prompt = """
 ## Role
 
-You are an issue triage assistant. You will retrieve issue data and available labels from environment variables, analyze the issues, and assign the most relevant labels. You will then return a single JSON array containing your triage decisions. Do NOT attempt to run any shell commands yourself; simply provide the JSON output.
+You are an issue triage assistant. GitHub issues are the source of truth for work tracking in this repository. You will retrieve issue data and available labels from environment variables, analyze the issues, and assign the most relevant labels. You will then return a single JSON array containing your triage decisions. Do NOT attempt to run any shell commands yourself; simply provide the JSON output.
 
 ## Guidelines
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,7 @@ Project-specific conventions
 - Commit messages: conventional form with agent prefix for automated commits (example: `ai(Cursor): update provider DI`). Keep small, focused commits.
 - Formatting & lint: run `flutter format .`, `flutter analyze` before pushing; Node code: `eslint`, `npm audit`.
 - DI pattern: `lib/di/locator.dart` registers services in `setupCoreServices()` and `setupAuthenticatedServices()` — prefer adding services via these functions.
+- GitHub issues are the work-tracking source of truth: `https://github.com/CloudToLocalLLM-online/CloudToLocalLLM/issues`. Treat issue bodies, comments, labels, milestones, and linked PRs as canonical for active work state and priority. Do not let local notes, chat context, or stale plans override a live issue without updating the issue.
 
 Integration & cross-component notes
 - Auth: Auth0 is used; web uses a JS bridge (`auth0-bridge.js`) while desktop uses native flows. See `auth_service.dart` and `auth0_*_service.dart`.

--- a/.github/workflows/app-builds.yml
+++ b/.github/workflows/app-builds.yml
@@ -100,3 +100,57 @@ jobs:
         with:
           name: windows-installer
           path: dist/windows/CloudToLocalLLM-Windows-x64-Setup.exe
+
+  build_android:
+    name: Android Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Version
+        if: inputs.version != ''
+        run: |
+          VERSION=${{ inputs.version }}
+          sed -i "s/^version: .*/version: $VERSION+${{ github.run_number }}/" pubspec.yaml
+          jq ".version = \"$VERSION\" | .build_number = \"${{ github.run_number }}\"" assets/version.json > assets/version.json.tmp && mv assets/version.json.tmp assets/version.json
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Decode Keystore
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 -d > android/release-keystore.jks
+
+      - name: Create key.properties
+        run: |
+          cat > android/key.properties << EOF
+          storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          storeFile=../release-keystore.jks
+          EOF
+
+      - name: Flutter Build APK
+        run: |
+          flutter pub get
+          flutter build apk --release --split-per-abi
+
+      - name: Upload APK (arm64-v8a)
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-arm64
+          path: build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+
+      - name: Upload APK (armeabi-v7a)
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-arm32
+          path: build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
+
+      - name: Upload APK (x86_64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-x86_64
+          path: build/app/outputs/flutter-apk/app-x86_64-release.apk

--- a/.github/workflows/app-builds.yml
+++ b/.github/workflows/app-builds.yml
@@ -14,6 +14,16 @@ on:
       windows_artifact:
         description: "Name of the uploaded Windows bundle"
         value: windows-bundle
+      windows_installer_artifact:
+        description: "Name of the uploaded Windows installer"
+        value: windows-installer
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Optional version string to apply before build"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   build_linux:
@@ -74,8 +84,19 @@ jobs:
           flutter pub get
           flutter build windows --release
 
+      - name: Build Windows Installer
+        shell: pwsh
+        run: |
+          ./scripts/packaging/build_windows_installer.ps1
+
       - name: Upload Windows Bundle
         uses: actions/upload-artifact@v4
         with:
           name: windows-bundle
           path: build/windows/x64/runner/Release/
+
+      - name: Upload Windows Installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: dist/windows/CloudToLocalLLM-Windows-x64-Setup.exe

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -219,6 +219,12 @@ jobs:
           name: windows-bundle
           path: build/windows/x64/runner/Release
 
+      - name: Download Windows Installer
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-installer
+          path: dist/windows
+
       - name: Package Linux Distributions
         run: |
           # Install FUSE for AppImage build
@@ -284,6 +290,7 @@ jobs:
             - **Arch Linux**: AUR package files in `dist/aur/`
 
             ### Windows
+            - Installer: `CloudToLocalLLM-Windows-x64-Setup.exe`
             - Portable ZIP: `CloudToLocalLLM-Windows-x64.zip`
 
             ## What's New
@@ -304,6 +311,7 @@ jobs:
           SHA_URL="${APPIMAGE_URL}.sha256"
           DEB_URL="https://github.com/CloudToLocalLLM-online/CloudToLocalLLM/releases/download/v${VERSION}/cloudtolocalllm_${VERSION}_amd64.deb"
           TARBALL_URL="https://github.com/CloudToLocalLLM-online/CloudToLocalLLM/releases/download/v${VERSION}/CloudToLocalLLM-Linux-x64.tar.gz"
+          WINDOWS_INSTALLER_URL="https://github.com/CloudToLocalLLM-online/CloudToLocalLLM/releases/download/v${VERSION}/CloudToLocalLLM-Windows-x64-Setup.exe"
           WINDOWS_URL="https://github.com/CloudToLocalLLM-online/CloudToLocalLLM/releases/download/v${VERSION}/CloudToLocalLLM-Windows-x64.zip"
 
           curl -fsSL -o /tmp/${APPIMAGE} "${APPIMAGE_URL}"
@@ -312,7 +320,7 @@ jobs:
           EXPECTED_SHA=$(awk '{print $1}' /tmp/${APPIMAGE}.sha256)
           test "$ACTUAL_SHA" = "$EXPECTED_SHA"
 
-          for url in "$DEB_URL" "$TARBALL_URL" "$WINDOWS_URL"; do
+          for url in "$DEB_URL" "$TARBALL_URL" "$WINDOWS_INSTALLER_URL" "$WINDOWS_URL"; do
             curl -fsSI "$url" >/dev/null
           done
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -72,7 +72,7 @@ jobs:
 
           COMPONENTS=""
           if echo "$DIFF_FILES" | grep -qE "services/api-backend/|config/docker/Dockerfile.api-backend"; then COMPONENTS="$COMPONENTS,api"; fi
-          if echo "$DIFF_FILES" | grep -qE "web/|lib/|build/web/|config/docker/Dockerfile.web|config/swarm/"; then COMPONENTS="$COMPONENTS,web,linux,windows"; fi
+          if echo "$DIFF_FILES" | grep -qE "web/|lib/|build/web/|config/docker/Dockerfile.web|config/swarm/"; then COMPONENTS="$COMPONENTS,web,linux,windows,android"; fi
           if echo "$DIFF_FILES" | grep -qE "config/docker/Dockerfile.postgres|config/docker/postgres-|config/docker/init.sql|services/postgres/"; then COMPONENTS="$COMPONENTS,postgres"; fi
           if echo "$DIFF_FILES" | grep -qE "config/docker/Dockerfile.streaming-proxy|services/streaming-proxy/"; then COMPONENTS="$COMPONENTS,streaming"; fi
 
@@ -225,6 +225,13 @@ jobs:
           name: windows-installer
           path: dist/windows
 
+      - name: Download Android APKs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: android-apk-*
+          path: dist/android
+          merge-multiple: true
+
       - name: Package Linux Distributions
         run: |
           # Install FUSE for AppImage build
@@ -266,7 +273,7 @@ jobs:
         id: create_release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "dist/linux/*,dist/windows/*,dist/aur/*"
+          artifacts: "dist/linux/*,dist/windows/*,dist/android/*,dist/aur/*"
           tag: "v${{ needs.ai_change_analysis.outputs.new_version }}"
           name: "Release v${{ needs.ai_change_analysis.outputs.new_version }}"
           artifactErrorsFailBuild: true
@@ -292,6 +299,11 @@ jobs:
             ### Windows
             - Installer: `CloudToLocalLLM-Windows-x64-Setup.exe`
             - Portable ZIP: `CloudToLocalLLM-Windows-x64.zip`
+
+            ### Android
+            - **ARM64** (most phones): `app-arm64-v8a-release.apk`
+            - **ARM32** (older devices): `app-armeabi-v7a-release.apk`
+            - **x86_64** (emulators/tablets): `app-x86_64-release.apk`
 
             ## What's New
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ certbot/
 *.key
 *.crt
 
+# Android signing (never commit)
+**/release-keystore.jks
+**/key.properties
+
 # Binary tools and local config
 .config/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,14 @@ Core orientation: secure agent channel, avatar/voice companion, desktop control,
 - Agent runtime management remains important but should not be the first UI surface.
 - Prefer Tailscale for secure private connectivity. The cloud connector model is one isolated container per user, joined to that user's tailnet.
 
+## GitHub issues are the work-tracking source of truth
+
+- Canonical issue tracker: `https://github.com/CloudToLocalLLM-online/CloudToLocalLLM/issues`
+- Treat GitHub issues, issue comments, labels, milestones, and linked PRs as the authoritative source of truth for active bugs, feature requests, prioritization, and execution status.
+- Do not treat ad hoc chat requests, stale plans, local TODO notes, or archived docs as authoritative if they conflict with the current GitHub issue state.
+- Before starting or changing substantive work, check for an existing issue, linked discussion, or open PR and align your work to that record.
+- If work is not represented in GitHub issues yet, create or update the relevant issue so the repo state and the agent's actions stay aligned.
+
 ## Commands
 
 ### Flutter app

--- a/docs/deployment/installation/WINDOWS.md
+++ b/docs/deployment/installation/WINDOWS.md
@@ -59,9 +59,8 @@ For a runtime on another machine, install Tailscale on both devices and confirm 
 Typical installer options:
 
 - Desktop shortcut
-- Start with Windows
-- System tray integration
-- Add to PATH where supported
+- Start Menu shortcut
+- URL callback registration for desktop auth flows
 
 ### Updates
 

--- a/docs/development/BUILD_SCRIPTS.md
+++ b/docs/development/BUILD_SCRIPTS.md
@@ -63,7 +63,14 @@ This guide explains the different build scripts available in CloudToLocalLLM and
 - **Size**: ~13MB (includes Flutter web build and all dependencies)
 - **Installation**: Extract and run `CloudToLocalLLM.exe`
 - **Advantages**: No installation required, portable, works on all Windows versions
-- **Recommended for**: All users, especially those who prefer portable applications
+- **Recommended for**: Testing, temporary use, and users who prefer portable applications
+
+### ✅ Inno Setup Installer Package
+
+- **Status**: Implemented in the GitHub Actions Windows build lane
+- **Output**: `CloudToLocalLLM-Windows-x64-Setup.exe`
+- **Installation**: Guided installer with Start Menu shortcut, optional desktop shortcut, and per-user URL-scheme registration
+- **Recommended for**: Most Windows users
 
 ### ❌ MSI Installer Package
 

--- a/docs/user-guide/SETUP_GUIDE.md
+++ b/docs/user-guide/SETUP_GUIDE.md
@@ -119,6 +119,8 @@ Get the latest release for your platform:
 2. Run the installer.
 3. Launch CloudToLocalLLM from the Start Menu.
 
+If you only need a temporary or portable setup, download the Windows ZIP bundle instead and run `CloudToLocalLLM.exe` directly.
+
 ### Linux AppImage
 
 ```bash

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,8 @@ import 'package:cloudtolocalllm/services/log_buffer_service.dart';
 import 'package:cloudtolocalllm/services/theme_provider.dart';
 import 'package:cloudtolocalllm/services/platform_detection_service.dart';
 import 'package:cloudtolocalllm/services/google_workspace_service.dart';
+import 'package:cloudtolocalllm/services/url_scheme_registration_service.dart'
+    if (dart.library.html) 'package:cloudtolocalllm/services/url_scheme_registration_service_stub.dart';
 import 'web_plugins_stub.dart'
     if (dart.library.html) 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:cloudtolocalllm/widgets/tray_initializer.dart';
@@ -64,7 +66,17 @@ void main([List<String> args = const []]) async {
 
   // TEMPORARY: Skip Sentry to test app loading
   debugPrint('[Main] Skipping Sentry for testing');
+  unawaited(_registerWindowsUrlScheme());
   _runAppWithoutSentry();
+}
+
+Future<void> _registerWindowsUrlScheme() async {
+  try {
+    final registered = await UrlSchemeRegistrationService.registerUrlScheme();
+    debugPrint('[Main] Windows URL scheme registration result: $registered');
+  } catch (e) {
+    debugPrint('[Main] Windows URL scheme registration failed: $e');
+  }
 }
 
 void _runAppWithoutSentry() {

--- a/lib/screens/onboarding/steps/welcome_step.dart
+++ b/lib/screens/onboarding/steps/welcome_step.dart
@@ -107,8 +107,8 @@ class _FeatureCards extends StatelessWidget {
         ),
         _FeatureCard(
           icon: Icons.hub_outlined,
-          title: 'OpenClaw Gateway',
-          description: 'Local AI management',
+          title: 'Agent Runtimes',
+          description: 'Hermes, OpenClaw, and compatible gateways',
         ),
         _FeatureCard(
           icon: Icons.face_outlined,

--- a/scripts/packaging/build_windows_installer.ps1
+++ b/scripts/packaging/build_windows_installer.ps1
@@ -1,0 +1,47 @@
+param(
+  [string]$SourceDir = "build/windows/x64/runner/Release",
+  [string]$OutputDir = "dist/windows",
+  [string]$Version = ""
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = (Resolve-Path (Join-Path $scriptRoot "../..")).Path
+Set-Location $projectRoot
+
+if (-not $Version) {
+  $versionLine = Select-String -Path "pubspec.yaml" -Pattern '^version:\s*(.+)$' | Select-Object -First 1
+  if (-not $versionLine) {
+    throw "Could not read version from pubspec.yaml"
+  }
+  $Version = ($versionLine.Matches[0].Groups[1].Value -split '\+')[0]
+}
+
+$resolvedSourceDir = (Resolve-Path $SourceDir).Path
+if (-not $resolvedSourceDir) {
+  throw "Windows release bundle not found at $SourceDir"
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+$resolvedOutputDir = (Resolve-Path $OutputDir).Path
+$installerScript = Join-Path $projectRoot "windows/installer/CloudToLocalLLM.iss"
+
+$isccCommand = (Get-Command iscc.exe -ErrorAction SilentlyContinue)?.Source
+if (-not $isccCommand) {
+  $fallback = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+  if (Test-Path $fallback) {
+    $isccCommand = $fallback
+  } else {
+    throw "ISCC.exe not found. Inno Setup is required on the Windows runner."
+  }
+}
+
+$arguments = @(
+  "/DMyAppVersion=$Version",
+  "/DMyAppSourceDir=$resolvedSourceDir",
+  "/DMyOutputDir=$resolvedOutputDir",
+  $installerScript
+)
+
+& $isccCommand @arguments

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(zoidbot LANGUAGES CXX)
+project(CloudToLocalLLM LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "zoidbot")
+set(BINARY_NAME "CloudToLocalLLM")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/installer/CloudToLocalLLM.iss
+++ b/windows/installer/CloudToLocalLLM.iss
@@ -1,0 +1,63 @@
+#ifndef MyAppVersion
+  #define MyAppVersion "0.0.0"
+#endif
+#ifndef MyAppSourceDir
+  #define MyAppSourceDir "build\\windows\\x64\\runner\\Release"
+#endif
+#ifndef MyOutputDir
+  #define MyOutputDir "dist\\windows"
+#endif
+
+#define MyAppName "CloudToLocalLLM"
+#define MyAppPublisher "CloudToLocalLLM"
+#define MyAppURL "https://cloudtolocalllm.online"
+#define MyAppExeName "CloudToLocalLLM.exe"
+#define MyAppProtocol "online.cloudtolocalllm.app"
+#define MyAppAssocName MyAppName + " Protocol"
+
+[Setup]
+AppId={{4D0715DA-A55B-48B5-9D1E-7E947DBA0F4A}}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={localappdata}\Programs\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+OutputDir={#MyOutputDir}
+OutputBaseFilename=CloudToLocalLLM-Windows-x64-Setup
+SetupIconFile=windows\runner\resources\app_icon.ico
+UninstallDisplayIcon={app}\{#MyAppExeName}
+Compression=lzma2/max
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+ChangesAssociations=yes
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional icons:"; Flags: unchecked
+
+[Files]
+Source: "{#MyAppSourceDir}\\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Registry]
+Root: HKCU; Subkey: "Software\Classes\{#MyAppProtocol}"; ValueType: string; ValueName: ""; ValueData: "URL:{#MyAppAssocName}"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\{#MyAppProtocol}"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletevalue
+Root: HKCU; Subkey: "Software\Classes\{#MyAppProtocol}\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#MyAppExeName},0"
+Root: HKCU; Subkey: "Software\Classes\{#MyAppProtocol}\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""%1"""
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; Flags: nowait postinstall skipifsilent

--- a/windows/register_scheme.reg
+++ b/windows/register_scheme.reg
@@ -1,15 +1,15 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\Classes\io.supabase.flutterquickstart]
+[HKEY_CURRENT_USER\Software\Classes\online.cloudtolocalllm.app]
 "URL Protocol"=""
-@="URL:Zoidbot Protocol"
+@="URL:CloudToLocalLLM Protocol"
 
-[HKEY_CURRENT_USER\Software\Classes\io.supabase.flutterquickstart\DefaultIcon]
-@="zoidbot.exe,0"
+[HKEY_CURRENT_USER\Software\Classes\online.cloudtolocalllm.app\DefaultIcon]
+@="CloudToLocalLLM.exe,0"
 
-[HKEY_CURRENT_USER\Software\Classes\io.supabase.flutterquickstart\shell]
+[HKEY_CURRENT_USER\Software\Classes\online.cloudtolocalllm.app\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\io.supabase.flutterquickstart\shell\open]
+[HKEY_CURRENT_USER\Software\Classes\online.cloudtolocalllm.app\shell\open]
 
-[HKEY_CURRENT_USER\Software\Classes\io.supabase.flutterquickstart\shell\open\command]
-@="\"C:\\Path\\To\\Your\\zoidbot.exe\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\online.cloudtolocalllm.app\shell\open\command]
+@="\"C:\\Path\\To\\Your\\CloudToLocalLLM.exe\" \"%1\""

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,13 +89,13 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "zoidbot" "\0"
+            VALUE "CompanyName", "CloudToLocalLLM" "\0"
+            VALUE "FileDescription", "CloudToLocalLLM Desktop Client" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "zoidbot" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "zoidbot.exe" "\0"
-            VALUE "ProductName", "zoidbot" "\0"
+            VALUE "InternalName", "CloudToLocalLLM" "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2026 CloudToLocalLLM. All rights reserved." "\0"
+            VALUE "OriginalFilename", "CloudToLocalLLM.exe" "\0"
+            VALUE "ProductName", "CloudToLocalLLM" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"zoidbot", origin, size)) {
+  if (!window.Create(L"CloudToLocalLLM", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
Restore a real Windows installer path for CloudToLocalLLM instead of shipping only a portable ZIP.

## What changed
- replace stale Windows runner `zoidbot` metadata with `CloudToLocalLLM`
- add Inno Setup installer source at `windows/installer/CloudToLocalLLM.iss`
- add `scripts/packaging/build_windows_installer.ps1`
- extend `.github/workflows/app-builds.yml` to:
  - support manual `workflow_dispatch`
  - build the Windows installer on `windows-latest`
  - upload `windows-installer` artifact
- extend `.github/workflows/deployment.yml` to:
  - include the installer asset in release packaging
  - mention installer + ZIP in release notes
  - verify installer download URL
- wire Windows URL scheme registration at app startup
- update Windows docs to match the real installer path

## Verification
- local source checks:
  - `/mnt/data/flutter-sdk/bin/flutter analyze lib/main.dart lib/services/url_scheme_registration_service.dart lib/services/url_scheme_registration_service_stub.dart`
  - result: `No issues found!`
- branch-only build verification in progress:
  - Actions run: `26139701881`
  - Workflow: `📦 App Builds`
  - Branch: `agent/windows-installer-path`

## Related issues
- Closes #329
- Closes #330
- Closes #331
- Related #328