### PR TITLE
fix(ci): harden all workflows with analyze gates, agent branch triggers, version dedup

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -23,14 +23,30 @@ permissions:
   packages: read
 
 jobs:
-  build_linux:
-    name: Linux Build
-    if: contains(inputs.platforms, 'linux')
+  analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+      - name: flutter analyze
+        run: |
+          flutter pub get
+          flutter analyze
+          echo "✅ Analysis passed"
 
-      - name: Set Version
+  set_version:
+    name: Set Version
+    needs: analyze
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute version
+        id: version
         run: |
           if [ -n "${{ inputs.version }}" ]; then
             VERSION=${{ inputs.version }}
@@ -40,6 +56,19 @@ jobs:
             v[2]=$((v[2] + 1))
             VERSION="${v[0]}.${v[1]}.${v[2]}"
           fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+  build_linux:
+    name: Linux Build
+    needs: set_version
+    if: contains(inputs.platforms, 'linux')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Version
+        run: |
+          VERSION=${{ needs.set_version.outputs.version }}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           sed -i "s/^version: .*/version: $VERSION+${{ github.run_number }}/" pubspec.yaml
           jq ".version = \"$VERSION\" | .build_number = \"${{ github.run_number }}\"" assets/version.json > assets/version.json.tmp && mv assets/version.json.tmp assets/version.json
@@ -92,6 +121,7 @@ jobs:
 
   build_windows:
     name: Windows Build
+    needs: set_version
     if: contains(inputs.platforms, 'windows')
     runs-on: windows-latest
     steps:
@@ -100,14 +130,7 @@ jobs:
       - name: Set Version
         shell: bash
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION=${{ inputs.version }}
-          else
-            VERSION=$(jq -r '.version' assets/version.json)
-            IFS='.' read -r -a v <<< "$VERSION"
-            v[2]=$((v[2] + 1))
-            VERSION="${v[0]}.${v[1]}.${v[2]}"
-          fi
+          VERSION=${{ needs.set_version.outputs.version }}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           sed -i "s/^version: .*/version: $VERSION+${{ github.run_number }}/" pubspec.yaml
           jq ".version = \"$VERSION\" | .build_number = \"${{ github.run_number }}\"" assets/version.json > assets/version.json.tmp && mv assets/version.json.tmp assets/version.json
@@ -137,6 +160,7 @@ jobs:
 
   build_macos:
     name: macOS Build
+    needs: set_version
     if: contains(inputs.platforms, 'macos')
     runs-on: macos-latest
     steps:
@@ -144,14 +168,7 @@ jobs:
 
       - name: Set Version
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION=${{ inputs.version }}
-          else
-            VERSION=$(jq -r '.version' assets/version.json)
-            IFS='.' read -r -a v <<< "$VERSION"
-            v[2]=$((v[2] + 1))
-            VERSION="${v[0]}.${v[1]}.${v[2]}"
-          fi
+          VERSION=${{ needs.set_version.outputs.version }}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           sed -i "" "s/^version: .*/version: $VERSION+${{ github.run_number }}/" pubspec.yaml
           jq ".version = \"$VERSION\" | .build_number = \"${{ github.run_number }}\"" assets/version.json > assets/version.json.tmp && mv assets/version.json.tmp assets/version.json
@@ -191,7 +208,7 @@ jobs:
           retention-days: 7
 
   create_release:
-    needs: [build_linux, build_windows, build_macos]
+    needs: [set_version, build_linux, build_windows, build_macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -18,8 +18,23 @@ permissions:
   packages: read
 
 jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+      - name: flutter analyze
+        run: |
+          flutter pub get
+          flutter analyze
+          echo "✅ Analysis passed"
+
   build_android:
     name: Android Build
+    needs: analyze
     if: contains(inputs.platforms, 'android')
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +72,7 @@ jobs:
 
   build_ios:
     name: iOS Build
+    needs: analyze
     if: contains(inputs.platforms, 'ios')
     runs-on: macos-latest
     steps:

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -2,7 +2,11 @@ name: "🖥️ Backend Deploy"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "antigravity/**"
+      - "zoidbot/**"
+      - "codex/**"
     paths:
       - "services/api-backend/**"
       - "services/streaming-proxy/**"
@@ -50,6 +54,7 @@ jobs:
         run: |
           set -euo pipefail
           REPO_LOWER=${GITHUB_REPOSITORY,,}
+          TAG_SUFFIX="${GITHUB_RUN_NUMBER}-${GITHUB_SHA:0:7}"
 
           if [ "${{ github.event_name }}" == "push" ]; then
             DIFF_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} || git diff --name-only HEAD^ HEAD)
@@ -57,25 +62,31 @@ jobs:
             DIFF_FILES=$(git diff --name-only HEAD^ HEAD || echo "api")
           fi
 
+          build_and_push() {
+            local name=$1 dockerfile=$2
+            echo "=== Building $name ==="
+            docker build -t ghcr.io/${REPO_LOWER}/${name}:build-${TAG_SUFFIX} -f $dockerfile .
+            # Only push to permanent tags on main
+            if [ "${{ github.ref_name }}" == "main" ]; then
+              docker tag ghcr.io/${REPO_LOWER}/${name}:build-${TAG_SUFFIX} ghcr.io/${REPO_LOWER}/${name}:latest
+              docker push ghcr.io/${REPO_LOWER}/${name}:latest
+              docker push ghcr.io/${REPO_LOWER}/${name}:build-${TAG_SUFFIX}
+            fi
+          }
+
           # API backend
           if echo "$DIFF_FILES" | grep -qE "services/api-backend/|config/docker/Dockerfile.api-backend" || [ "${{ inputs.force_build }}" == "true" ]; then
-            echo "=== Building API Backend ==="
-            docker build -t ghcr.io/${REPO_LOWER}/api-backend:latest -f config/docker/Dockerfile.api-backend .
-            docker push ghcr.io/${REPO_LOWER}/api-backend:latest
+            build_and_push api-backend config/docker/Dockerfile.api-backend
           fi
 
           # Streaming proxy
           if echo "$DIFF_FILES" | grep -qE "services/streaming-proxy/|config/docker/Dockerfile.streaming-proxy" || [ "${{ inputs.force_build }}" == "true" ]; then
-            echo "=== Building Streaming Proxy ==="
-            docker build -t ghcr.io/${REPO_LOWER}/streaming-proxy:latest -f config/docker/Dockerfile.streaming-proxy .
-            docker push ghcr.io/${REPO_LOWER}/streaming-proxy:latest
+            build_and_push streaming-proxy config/docker/Dockerfile.streaming-proxy
           fi
 
           # Postgres
           if echo "$DIFF_FILES" | grep -qE "config/docker/Dockerfile.postgres|config/docker/postgres-|config/docker/init.sql|services/postgres/" || [ "${{ inputs.force_build }}" == "true" ]; then
-            echo "=== Building Postgres ==="
-            docker build -t ghcr.io/${REPO_LOWER}/postgres:latest -f config/docker/Dockerfile.postgres .
-            docker push ghcr.io/${REPO_LOWER}/postgres:latest
+            build_and_push postgres config/docker/Dockerfile.postgres
           fi
 
-          echo "✅ Backend images built and pushed"
+          echo "✅ Backend images built"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -2,7 +2,11 @@ name: "🌐 Web Deploy"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "antigravity/**"
+      - "zoidbot/**"
+      - "codex/**"
     paths:
       - "lib/**"
       - "web/**"
@@ -21,7 +25,22 @@ permissions:
   packages: write
 
 jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+      - name: flutter analyze
+        run: |
+          flutter pub get
+          flutter analyze
+          echo "✅ Analysis passed"
+
   build_and_deploy:
+    needs: analyze
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -44,6 +63,7 @@ jobs:
           retention-days: 1
 
       - name: Deploy to Simon VPS
+        if: github.ref_name == 'main'
         env:
           VM_SSH_PRIVATE_KEY: ${{ secrets.VM_SSH_PRIVATE_KEY }}
           SIMON_HOST: 31.97.140.7


### PR DESCRIPTION
## Summary

Harden all 4 CI workflows with quality gates, agent branch support, and cleaner CD logic.

### Changes per workflow

**`deploy-web.yml` 🌐**
- Added `flutter analyze` gate before build (catches broken imports, saves 2min on each failed build)
- VPS deploy now gated to `main` only — agent branches get full CI feedback but don't deploy to production
- Agent branch triggers (`antigravity/**`, `zoidbot/**`, `codex/**`)

**`deploy-backend.yml` 🖥️**
- Agent branch triggers with build-only on branches, push+tag only on main
- Version-tagged Docker images (`build-{run}-{sha}`) instead of bare `:latest`

**`build-desktop.yml` 💻**
- `flutter analyze` gate
- Deduplicated version logic — shared `set_version` job instead of 3 copies

**`build-mobile.yml` 📱**
- `flutter analyze` gate

### Why
- No more pushing broken Flutter code that fails 2min into the build when analyze would catch it in 15s
- Agent branches get CI without deploying broken builds to production
- Clean separation of CI (runs everywhere) from CD (deploy/release only from main)