### PR TITLE
fix: block home layout render until setup check completes, no async flash

### DIFF
--- a/lib/config/router.dart
+++ b/lib/config/router.dart
@@ -193,6 +193,8 @@ class _HomeWithSetupCheck extends StatefulWidget {
 }
 
 class _HomeWithSetupCheckState extends State<_HomeWithSetupCheck> {
+  bool _checking = true;
+
   @override
   void initState() {
     super.initState();
@@ -202,26 +204,38 @@ class _HomeWithSetupCheckState extends State<_HomeWithSetupCheck> {
   Future<void> _checkSetupNeeded() async {
     if (kIsWeb) {
       // Setup wizard is desktop-only, skip check on web
+      if (mounted) setState(() => _checking = false);
       return;
     }
     try {
       final setupWizardService = serviceLocator<SetupWizardService>();
       final shouldShow = await setupWizardService.shouldShowWizard();
 
-      if (shouldShow && mounted) {
+      if (!mounted) return;
+
+      if (shouldShow) {
         debugPrint(
             '[Router] No providers configured, redirecting to setup wizard');
-        if (mounted) {
-          context.go('/setup');
-        }
+        context.go('/setup');
+      } else {
+        setState(() => _checking = false);
       }
     } catch (e) {
       debugPrint('[Router] Error checking setup status: $e');
+      if (mounted) setState(() => _checking = false);
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    // Block rendering the child until the setup check completes.
+    // Prevents flash of "No Agent Connected" home screen while the async
+    // check determines the wizard redirect is needed.
+    if (_checking) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
     return widget.child;
   }
 }
@@ -248,10 +262,6 @@ class AppRouter {
           initialLocation += '?${currentUri.query}';
         }
       }
-    } else {
-      // On desktop, always start at /setup so the wizard renders immediately
-      // (no async flash of "No Agent Connected" before the redirect fires).
-      initialLocation = '/setup';
     }
     debugPrint('[Router] Initial location: $initialLocation');
 

--- a/lib/config/router.dart
+++ b/lib/config/router.dart
@@ -248,6 +248,10 @@ class AppRouter {
           initialLocation += '?${currentUri.query}';
         }
       }
+    } else {
+      // On desktop, always start at /setup so the wizard renders immediately
+      // (no async flash of "No Agent Connected" before the redirect fires).
+      initialLocation = '/setup';
     }
     debugPrint('[Router] Initial location: $initialLocation');
 


### PR DESCRIPTION
## Problem

On first launch, the desktop app shows "No Agent Connected" instead of the setup wizard. The home screen renders its "No Agent Connected" UI (including the warning icon and "Download Companion App" button) BEFORE the async `_checkSetupNeeded()` has a chance to redirect to `/setup`.

## Root Cause

`_HomeWithSetupCheck.initState()` calls the async `_checkSetupNeeded()` which checks `shouldShowWizard()` and redirects via `context.go('/setup')`. But GoRouter renders the shell route's child (the full home layout with "No Agent Connected") immediately — the redirect happens too late.

## Fix

`_HomeWithSetupCheck` now blocks rendering its child with a `_checking` flag. While the async setup check runs, it shows a minimal loading spinner. Only after confirming setup is NOT needed does it render the home layout. If setup IS needed, the GoRouter redirect to `/setup` fires before any home UI renders.