### PR TITLE
fix: use env var instead of secrets context in AUR publish step guard

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -222,8 +222,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to AUR
-        if: ${{ secrets.AUR_SSH_KEY != '' }}
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
         run: |
+          if [ -z "$AUR_SSH_KEY" ]; then
+            echo "AUR_SSH_KEY not set — skipping AUR publish"
+            exit 0
+          fi
           set -euo pipefail
           VERSION="${{ env.VERSION }}"
           mkdir -p ~/.ssh


### PR DESCRIPTION
Fix AUR publish step guard — `secrets.` is not valid in `if:` expression context.

Changed from `if: ${{ secrets.AUR_SSH_KEY != '' }}` (parser error) to passing as `env:` with a shell-level guard.