### PR TITLE
fix: resolve CI flutter analyze errors for locator and local_tts_service

### DIFF
--- a/lib/di/locator.dart
+++ b/lib/di/locator.dart
@@ -363,7 +363,6 @@ Future<void> setupCoreServices() async {
     // App initialization service - manages initialization order
     final appInitializationService = AppInitializationService(
       authService: authService,
-      connectionManager: () => serviceLocator.get<ConnectionManagerService>(),
     );
     serviceLocator.registerSingleton<AppInitializationService>(
       appInitializationService,
@@ -575,7 +574,6 @@ Future<void> _registerWebFallbackCoreServices() async {
     serviceLocator.registerSingleton<AppInitializationService>(
       AppInitializationService(
         authService: serviceLocator.get<AuthService>(),
-        connectionManager: () => serviceLocator.get<ConnectionManagerService>(),
       ),
     );
   }

--- a/lib/services/voice/local_tts_service.dart
+++ b/lib/services/voice/local_tts_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 


### PR DESCRIPTION
Fix two CI build errors found in `flutter analyze`:
1. `connectionManager` named parameter no longer exists on `AppInitializationService`
2. Add explicit `dart:typed_data` import to fix deprecated indirect `BytesBuilder` import