### PR TITLE
fix: typo removeAritifacts -> removeArtifacts in release action

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -201,7 +201,7 @@ jobs:
           name: "Release v${{ env.VERSION }}"
           artifactErrorsFailBuild: false
           allowUpdates: true
-          removeAritifacts: true
+          removeArtifacts: true
           makeLatest: true
           body: |
             ## Desktop Release v${{ env.VERSION }}


### PR DESCRIPTION
Fix typo in ncipollo/release-action config: `removeAritifacts` -> `removeArtifacts`.

This was silently ignored by the action (unknown param), so the old behavior was the same — but it's a typo that should be fixed before it causes confusion.