### PR TITLE
fix: replace broken `command -v` check with `which` in LocalVoiceInputService

### DIFF
--- a/lib/services/voice/local_voice_input_service.dart
+++ b/lib/services/voice/local_voice_input_service.dart
@@ -262,8 +262,8 @@ class LocalVoiceInputService {
 
   Future<bool> _hasCommand(String command) async {
     try {
-      final result = await Process.run('command', ['-v', command]);
-      return result.exitCode == 0;
+      final result = await Process.run('which', [command]);
+      return result.exitCode == 0 && result.stdout.toString().trim().isNotEmpty;
     } catch (_) {
       return false;
     }


### PR DESCRIPTION
The original fix (#363) was overwritten by subsequent streamer-co-pilot work on main. The `Process.run('command', ['-v', ...])` call doesn't work in Dart because `command` is a shell built-in, not a real binary. This caused `startCapture()` to fail immediately.

Re-applying the fix: use `which` instead, which is a real binary and returns the path on success.