### PR TITLE
fix: packaging script validation paths, dead tunnel port, stale setup path (#327)

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -48,9 +48,9 @@ class AppConfig {
   static const Duration apiTimeout = Duration(seconds: 30);
   // Tunnel Configuration (SSH over WebSocket)
   static const String tunnelSshUrl =
-      'wss://api.cloudtolocalllm.online:8080/ssh';
+      'wss://api.cloudtolocalllm.online/ssh';
   static const String tunnelSshUrlDev =
-      'wss://api.cloudtolocalllm.online:8080/ssh';
+      'wss://api.cloudtolocalllm.online/ssh';
   // UI Configuration
   static const double maxContentWidth = 1200.0;
   static const double mobileBreakpoint = 768.0;

--- a/scripts/packaging/build_all_packages.sh
+++ b/scripts/packaging/build_all_packages.sh
@@ -188,9 +188,9 @@ validate_packages() {
     local validation_errors=0
 
     # Check Debian package
-    if [[ -f "$dist_dir/cloudtolocalllm-${version}-amd64.deb" ]]; then
-        log_success "Debian package found: CloudToLocalLLM-${version}-amd64.deb"
-        if [[ -f "$dist_dir/cloudtolocalllm-${version}-amd64.deb.sha256" ]]; then
+    if [[ -f "$dist_dir/CloudToLocalLLM_${version}_amd64.deb" ]]; then
+        log_success "Debian package found: CloudToLocalLLM_${version}_amd64.deb"
+        if [[ -f "$dist_dir/CloudToLocalLLM_${version}_amd64.deb.sha256" ]]; then
             log_success "Debian package checksum found"
         else
             log_error "Debian package checksum missing"
@@ -241,9 +241,9 @@ generate_summary() {
     echo "Generated Packages:"
 
     # List all generated packages with sizes
-    if [[ -f "$dist_dir/cloudtolocalllm-${version}-amd64.deb" ]]; then
-        local size=$(du -h "$dist_dir/cloudtolocalllm-${version}-amd64.deb" | cut -f1)
-        echo "  Debian: CloudToLocalLLM-${version}-amd64.deb ($size)"
+    if [[ -f "$dist_dir/CloudToLocalLLM_${version}_amd64.deb" ]]; then
+        local size=$(du -h "$dist_dir/CloudToLocalLLM_${version}_amd64.deb" | cut -f1)
+        echo "  Debian: CloudToLocalLLM_${version}_amd64.deb ($size)"
     fi
 
     if [[ -f "$dist_dir/cloudtolocalllm-${version}-x86_64.AppImage" ]]; then

--- a/scripts/setup-development-environment.sh
+++ b/scripts/setup-development-environment.sh
@@ -45,7 +45,7 @@ check_command() {
     fi
 }
 
-REPO_ROOT="/mnt/data/projects/CloudToLocalLLM"
+REPO_ROOT="/home/rightguy/CloudToLocalLLM"
 log_info "Starting CloudToLocalLLM development environment setup..."
 log_info "Target directory: $REPO_ROOT"
 


### PR DESCRIPTION
## Changes

| File | Issue | Fix |
|---|---|---|
| `scripts/packaging/build_all_packages.sh` | Validation checked `cloudtolocalllm-${version}-amd64.deb` but build produces `CloudToLocalLLM_${version}_amd64.deb` (uppercase C, underscores) | Fixed validation + summary paths to match actual output |
| `lib/config/app_config.dart` | `tunnelSshUrl` used `wss://api.cloudtolocalllm.online:8080/ssh` — port 8080 is dead, API runs on port 443 via Cloudflare | Removed `:8080` port |
| `scripts/setup-development-environment.sh` | `REPO_ROOT` set to stale `/mnt/data/projects/CloudToLocalLLM` | Changed to `/home/rightguy/CloudToLocalLLM` |

Partially addresses #327.