### PR TITLE
fix: resolve 3 Flutter analyze errors

### DIFF
--- a/apps/streamer_co_pilot/test/widget_test.dart
+++ b/apps/streamer_co_pilot/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:streamer_co_pilot/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const StreamerCoPilotApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);

--- a/test/services/platform_category_filter_test.dart
+++ b/test/services/platform_category_filter_test.dart
@@ -61,9 +61,6 @@ class _MockAuthService extends ChangeNotifier implements AuthService {
       true;
 
   @override
-  Future<void> loginMockDeveloper() async {}
-
-  @override
   void dispose() {
     isAuthenticated.dispose();
     isLoading.dispose();

--- a/test/services/platform_detection_timing_test.dart
+++ b/test/services/platform_detection_timing_test.dart
@@ -226,9 +226,6 @@ class _MinimalAuthService extends ChangeNotifier implements AuthService {
   @override
   Future<void> logout() async {}
 
-  @override
-  Future<void> loginMockDeveloper() async {}
-
 
   @override
   Future<void> get sessionBootstrapFuture async {}

--- a/test/widgets/account_settings_category_test.dart
+++ b/test/widgets/account_settings_category_test.dart
@@ -74,9 +74,6 @@ class MockAuthService extends ChangeNotifier implements AuthService {
   Future<void> login({String? tenantId}) async {}
 
   @override
-  Future<void> loginMockDeveloper() async {}
-
-  @override
   Future<String?> getAccessToken() async => 'test-token';
 
   @override


### PR DESCRIPTION
## What Changed
- Removed duplicate  method declarations in 3 test files
- Fixed  →  in streamer_co_pilot widget test

## Verification
```
flutter analyze --no-fatal-infos: 0 errors (was 3)
backend tests: 3223/3223 pass
```

## Model Used
DeepSeek V4 Flash (Ollama Cloud)