### PR TITLE
ci: fix Actions deprecations + Windows build deps

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -24,10 +24,10 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
@@ -40,11 +40,11 @@ jobs:
   set_version:
     name: Set Version
     needs: analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Compute version
         id: version
         run: |
@@ -62,9 +62,9 @@ jobs:
     name: Linux Build
     needs: set_version
     if: contains(inputs.platforms, 'linux')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set Version
         run: |
@@ -113,7 +113,7 @@ jobs:
           ./scripts/packaging/build_installer.sh
 
       - name: Upload Linux Bundles
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: linux-bundles
           path: dist/linux/*
@@ -123,9 +123,9 @@ jobs:
     name: Windows Build
     needs: set_version
     if: contains(inputs.platforms, 'windows')
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set Version
         shell: bash
@@ -140,6 +140,13 @@ jobs:
           channel: "stable"
           cache: true
 
+      - name: Install Windows Dependencies (cpprestsdk)
+        shell: pwsh
+        run: |
+          # auth0_flutter needs cpprestsdk — install via vcpkg
+          vcpkg install cpprestsdk --triplet x64-windows
+          echo "CPPRESTSDK_DIR=C:\vcpkg\installed\x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Flutter Build Windows
         run: |
           flutter pub get
@@ -150,7 +157,7 @@ jobs:
         run: ./scripts/packaging/build_windows_installer.ps1
 
       - name: Upload Windows Bundles
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: windows-bundles
           path: |
@@ -160,14 +167,15 @@ jobs:
 
   create_release:
     needs: [set_version, build_linux, build_windows]
-    runs-on: ubuntu-latest
+    if: always() && needs.build_linux.result == 'success'
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
 
       - name: Compute version
         run: |

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -19,10 +19,10 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
@@ -36,9 +36,9 @@ jobs:
     name: Android Build
     needs: analyze
     if: contains(inputs.platforms, 'android')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
@@ -64,7 +64,7 @@ jobs:
           flutter build apk --release --split-per-abi --android-skip-build-dependency-validation
 
       - name: Upload APKs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: android-apks
           path: build/app/outputs/flutter-apk/*.apk
@@ -74,9 +74,9 @@ jobs:
     name: iOS Build
     needs: analyze
     if: contains(inputs.platforms, 'ios')
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
@@ -89,7 +89,7 @@ jobs:
           flutter build ios --release --no-codesign
 
       - name: Upload iOS build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ios-build
           path: build/ios/iphoneos/Runner.app

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -38,9 +38,9 @@ permissions:
 
 jobs:
   build_images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -26,10 +26,10 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
@@ -51,10 +51,10 @@ jobs:
 
   build_and_deploy:
     needs: analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
@@ -66,7 +66,7 @@ jobs:
           flutter build web --release --no-tree-shake-icons
 
       - name: Upload web build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: web-build
           path: build/web/

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -17,9 +17,9 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine version
         id: version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,11 @@ permissions:
 jobs:
   flutter_analyze:
     name: "🔍 Flutter Analyze"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
@@ -46,12 +46,12 @@ jobs:
 
   flutter_unit_test:
     name: "🧪 Flutter — unit tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
@@ -72,12 +72,12 @@ jobs:
 
   flutter_integration_test:
     name: "🧪 Flutter — integration (allow fail)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
@@ -93,12 +93,12 @@ jobs:
 
   build_web:
     name: "🌐 Build Web"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [flutter_analyze, flutter_unit_test]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
@@ -112,7 +112,7 @@ jobs:
         run: flutter build web --release
 
       - name: "📦 Upload web build"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: web-build
           path: build/web/
@@ -120,12 +120,12 @@ jobs:
 
   build_linux:
     name: "🐧 Build Linux Desktop"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: [flutter_analyze, flutter_unit_test]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
@@ -154,7 +154,7 @@ jobs:
           tar -czf /tmp/cloudtolocalllm-linux-x64.tar.gz bundle/
 
       - name: "📦 Upload Linux build"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: linux-build
           path: /tmp/cloudtolocalllm-linux-x64.tar.gz
@@ -162,16 +162,16 @@ jobs:
 
   backend:
     name: "Backend — lint + test"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     defaults:
       run:
         working-directory: services/api-backend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
## What

Fixes **6 workflow files** across the board to eliminate Node.js 20 deprecation warnings and fix the Windows build failure.

### Changes

- **actions/checkout @v4 → @v5** — Node.js 20 deprecation (deadline June 16)
- **upload-artifact @v4 → @v5** — same deprecation
- **download-artifact @v4 → @v5** — same deprecation
- **actions/setup-node @v4 → @v5** — same deprecation
- **Runner images pinned explicitly**: ubuntu-24.04, windows-2025-vs2026, macos-15 (no more "latest" guesswork)
- **Windows build fix**: install `cpprestsdk` via vcpkg (required by `auth0_flutter` plugin's CMake config)
- **create_release** now uses `if: always() && needs.build_linux.result == 'success'` so Windows build can fail without blocking the Linux release

### Files changed

| File | Changes |
|------|---------|
| build-desktop.yml | 34 changes — deps bump, vcpkg step, runner pin, resilient release |
| build-mobile.yml | 18 changes — deps bump, runner pin |
| deploy-backend.yml | 6 changes — deps bump, runner pin |
| deploy-web.yml | 12 changes — deps bump, runner pin |
| publish-aur.yml | 6 changes — deps bump, runner pin |
| test.yml | 30 changes — deps bump, runner pin |