### PR TITLE
fix(web): kill stuck splash on first frame or 8s timeout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -109,6 +109,10 @@
       document.getElementById("splash-branding")?.remove();
       document.body.style.background = "transparent";
     }
+    // Fallback: kill the splash after first frame if Flutter engine never calls us
+    window.addEventListener('flutter-first-frame', removeSplashFromWeb);
+    // Hard timeout: if first-frame never fires, kill it anyway after 8s
+    setTimeout(removeSplashFromWeb, 8000);
   </script>
 </head>
 


### PR DESCRIPTION
Binds removeSplashFromWeb to the flutter-first-frame event and adds an 8s hard timeout, so the Aiman splash HTML never gets stuck on top of the app when Flutter bootstrap hangs.

Fixes the web build where the splash `<picture id="splash">` in `web/index.html` stays visible forever if the engine never reaches first-frame (e.g. setupServiceLocator stalled).

`deploy-web.yml` already triggers on `web/**` push, so this PR will build and deploy to Simon VPS once merged.