### PR TITLE
fix: GatewayControlService stop() on unknown state + dispose-after-async

### DIFF
--- a/lib/services/openclaw_manager/gateway_control_service.dart
+++ b/lib/services/openclaw_manager/gateway_control_service.dart
@@ -22,6 +22,7 @@ class GatewayControlService extends ChangeNotifier {
   final SettingsPreferenceService _settings;
   bool _autoRestartEnabled = true;
   int _restartAttempts = 0;
+  bool _isDisposed = false;
   static const int _maxRestartAttempts = 5;
   ConnectionManagerService? _connectionManager;
 
@@ -65,7 +66,9 @@ class GatewayControlService extends ChangeNotifier {
 
   Future<void> _loadAutoRestartSetting() async {
     _autoRestartEnabled = await _settings.getGatewayAutoRestart() ?? true;
-    notifyListeners();
+    if (!_isDisposed) {
+      notifyListeners();
+    }
   }
 
   Future<void> setAutoRestart(bool enabled) async {
@@ -109,7 +112,9 @@ class GatewayControlService extends ChangeNotifier {
   }
 
   Future<bool> stop() async {
-    if (_state == GatewayState.stopped || _state == GatewayState.stopping) {
+    if (_state == GatewayState.stopped ||
+        _state == GatewayState.stopping ||
+        _state == GatewayState.unknown) {
       return true;
     }
 
@@ -227,6 +232,7 @@ class GatewayControlService extends ChangeNotifier {
 
   @override
   void dispose() {
+    _isDisposed = true;
     _healthCheckTimer?.cancel();
     if (_connectionManager != null) {
       _connectionManager!.removeListener(_onConnectionChanged);


### PR DESCRIPTION
## Summary

2 bug fixes in `GatewayControlService`:

### 1. `stop()` treats `unknown` state as already stopped
Previously, `stop()` only returned `true` for `stopped` or `stopping` states. When state was `unknown` (never started), it attempted `Process.run('openclaw', ...)` which would fail. Now `unknown` is treated as a no-op stop, returning `true` immediately.

### 2. `_loadAutoRestartSetting()` fires `notifyListeners()` after `dispose()`
The constructor fires `_loadAutoRestartSetting()` asynchronously, which calls `notifyListeners()`. If the test creates the service, checks values, then calls `dispose()`, the async callback from `_loadAutoRestartSetting` can fire after disposal, throwing `"A GatewayControlService was used after being disposed."` Fixed by adding `_isDisposed` flag.

## Test Results

```
8 passed, 0 failed (was 4 failed)
```