### PR TITLE
fix: PopOutButton gracefully handles missing GetIt registration

### DIFF
--- a/lib/services/popout/popout_manager.dart
+++ b/lib/services/popout/popout_manager.dart
@@ -47,12 +47,13 @@ class PopOutManager extends ChangeNotifier {
   ///
   /// If window is open, closes it. If closed and enabled, opens it.
   void togglePopOut(String sectionName, int branchIndex) {
-    final existingWindow = _openWindows[sectionName];
+    final key = '$sectionName:$branchIndex';
+    final existingWindow = _openWindows[key];
 
     if (existingWindow != null) {
       // Window is open, close it
-      _openWindows.remove(sectionName);
-      debugPrint('[PopOutManager] Closed window for section: $sectionName');
+      _openWindows.remove(key);
+      debugPrint('[PopOutManager] Closed window for section: $sectionName branch: $branchIndex');
     } else {
       // Window is closed, check if enabled
       if (!isSectionPopOutEnabled(sectionName)) {
@@ -63,13 +64,13 @@ class PopOutManager extends ChangeNotifier {
 
       // Open new window
       final newWindow = PopOutWindow(
-        id: sectionName,
+        id: key,
         sectionName: sectionName,
         branchIndex: branchIndex,
         isVisible: true,
       );
-      _openWindows[sectionName] = newWindow;
-      debugPrint('[PopOutManager] Opened window for section: $sectionName');
+      _openWindows[key] = newWindow;
+      debugPrint('[PopOutManager] Opened window for section: $sectionName branch: $branchIndex');
     }
 
     notifyListeners();

--- a/lib/widgets/navigation/popout_button.dart
+++ b/lib/widgets/navigation/popout_button.dart
@@ -14,25 +14,48 @@ class PopOutButton extends StatelessWidget {
   /// Branch index for multiple instances of the same section
   final int branchIndex;
 
+  /// Optional manager override (useful for testing without GetIt registration)
+  final PopOutManager? manager;
+
   const PopOutButton({
     super.key,
     required this.sectionName,
     this.branchIndex = 0,
+    this.manager,
   });
 
   @override
   Widget build(BuildContext context) {
+    final popOutManager = manager ?? _tryResolveFromGetIt();
+    if (popOutManager == null) {
+      // GetIt not configured (e.g. in tests) — render a no-op button
+      return IconButton(
+        icon: const Icon(Icons.open_in_new),
+        tooltip: 'Toggle pop-out window',
+        onPressed: null,
+      );
+    }
+
     return ChangeNotifierProvider<PopOutManager>.value(
-      value: di.serviceLocator<PopOutManager>(),
+      value: popOutManager,
       child: Consumer<PopOutManager>(
-        builder: (context, manager, child) {
+        builder: (context, mgr, child) {
           return IconButton(
             icon: const Icon(Icons.open_in_new),
             tooltip: 'Toggle pop-out window',
-            onPressed: () => manager.togglePopOut(sectionName, branchIndex),
+            onPressed: () => mgr.togglePopOut(sectionName, branchIndex),
           );
         },
       ),
     );
+  }
+
+  /// Attempt to resolve PopOutManager from GetIt; return null if not registered.
+  PopOutManager? _tryResolveFromGetIt() {
+    try {
+      return di.serviceLocator<PopOutManager>();
+    } catch (_) {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Two fixes:

### 1. PopOutButton gracefully handles missing GetIt registration
`PopOutButton` unconditionally called `di.serviceLocator<PopOutManager>()` in `build()`, throwing `StateError` in any test that renders a screen containing a `PopOutButton` without full DI setup.

- Try to resolve `PopOutManager` from GetIt with try-catch; return `null` if not registered
- When `null`, render a disabled no-op `IconButton` instead of crashing
- Add optional `manager` parameter for direct injection in tests

### 2. PopOutManager uses branch-aware keys for window tracking
`togglePopOut` used `sectionName` as the map key, so calling `togglePopOut("agents", 0)` then `togglePopOut("agents", 1)` would close the first window instead of opening a second branch. Fixed: key is now `"$sectionName:$branchIndex"`, matching the test expectation for independent branch windows.

## Test Results

- `popout_manager_test`: 2 passed (was 2 failed)
- `cockpit_screens_test`, `nodes_screen_test`: no longer crash with GetIt StateError