### PR TITLE
fix(ui): Row overflow in SkillsScreen skill card

### DIFF
--- a/lib/screens/skills/skills_screen.dart
+++ b/lib/screens/skills/skills_screen.dart
@@ -290,14 +290,17 @@ class _SkillsScreenState extends State<SkillsScreen>
                     children: [
                       Row(
                         children: [
-                          Text(
-                            skill.name,
-                            style: theme.textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.w600,
-                              color: skill.enabled
-                                  ? null
-                                  : theme.colorScheme.onSurface
-                                      .withValues(alpha: 0.6),
+                          Expanded(
+                            child: Text(
+                              skill.name,
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                                color: skill.enabled
+                                    ? null
+                                    : theme.colorScheme.onSurface
+                                        .withValues(alpha: 0.6),
+                              ),
+                              overflow: TextOverflow.ellipsis,
                             ),
                           ),
                           const SizedBox(width: 8),

--- a/test/widgets/management_screens_test.dart
+++ b/test/widgets/management_screens_test.dart
@@ -42,10 +42,7 @@ void main() {
   });
 
   group('SkillsScreen', () {
-    // TODO: SkillsScreen has a Row overflow bug at skills_screen.dart:291 —
-    // the category/version row overflows at default 800px test width.
-    // Re-enable after fixing the Row layout (use Expanded/Flexible).
-    testWidgets('renders skills list after loading', skip: true, (tester) async {
+    testWidgets('renders skills list after loading', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: const SizedBox(


### PR DESCRIPTION
## Summary
Fixes the Row overflow bug at `skills_screen.dart:291` that caused the skill name + category Chip to overflow at narrow widths.

- Wrap skill name  in  with 
- Unskip the SkillsScreen widget test (was skipped in #428 due to this bug)

All 3 management screen tests now pass (AgentsScreen, SkillsScreen, CronJobsScreen).