### PR TITLE
fix(wizard): apply 6 documented auto-detection fixes + 4 additional gaps

### DIFF
--- a/lib/config/theme.dart
+++ b/lib/config/theme.dart
@@ -7,25 +7,25 @@ import 'theme_extensions.dart';
 /// This class now delegates to ThemeConfig for unified theme management.
 /// Use ThemeConfig directly for new implementations.
 class AppTheme {
-  // Color scheme matching CloudToLocalLLM lobster branding
+  // Color scheme — Pistisai Gold-on-Dark palette
   static const Color primaryColor = Color(
-    0xFFFF0000,
-  ); // Lobster red
+    0xFFD4AF37,
+  ); // Pistis Gold
   static const Color secondaryColor = Color(
-    0xFFFF7F00,
-  ); // Lobster orange
-  static const Color accentColor = Color(0xFF000000); // Black
+    0xFFE8C547,
+  ); // Warm Amber Gold
+  static const Color accentColor = Color(0xFFC9A227); // Deep Gold
 
   // Background colors
-  static const Color backgroundMain = Color(0xFF000000); // Black
-  static const Color backgroundCard = Color(0xFF000000); // Black
+  static const Color backgroundMain = Color(0xFF0F0F1A); // Warm dark
+  static const Color backgroundCard = Color(0xFF1A1A2E); // Card
   static const Color backgroundLight = Color(0xFFf5f5f5); // --bg-light: #f5f5f5
 
   // Text colors
-  static const Color textColor = Color(0xFFf1f1f1); // --text-color: #f1f1f1
+  static const Color textColor = Color(0xFFF5E6C8); // Warm cream
   static const Color textColorLight = Color(
-    0xFFb0b0b0,
-  ); // --text-color-light: #b0b0b0
+    0xFFB8A88A,
+  ); // Muted gold-grey
   static const Color textColorDark = Color(
     0xFF2c3e50,
   ); // --text-color-dark: #2c3e50
@@ -37,7 +37,7 @@ class AppTheme {
   static const Color infoColor = Color(0xFF2196f3);
 
   // Border colors
-  static const Color borderColor = Color(0xFF3a3a3a);
+  static const Color borderColor = Color(0xFF2A2A3E);
 
   // Gradients matching homepage
   static const LinearGradient headerGradient = LinearGradient(

--- a/lib/config/theme_config.dart
+++ b/lib/config/theme_config.dart
@@ -24,23 +24,23 @@ class ThemeConfig {
   // Color Definitions
   // ============================================================================
 
-  /// Primary brand color (Lobster Red)
-  static const Color primaryColor = Color(0xFFFF0000);
+  /// Primary brand color (Pistis Gold)
+  static const Color primaryColor = Color(0xFFD4AF37);
 
-  /// Secondary brand color (Lobster Orange)
-  static const Color secondaryColor = Color(0xFFFF7F00);
+  /// Secondary brand color (Warm Amber Gold)
+  static const Color secondaryColor = Color(0xFFE8C547);
 
-  /// Accent color (Black)
-  static const Color accentColor = Color(0xFF000000);
+  /// Accent color (Deep Gold)
+  static const Color accentColor = Color(0xFFC9A227);
 
   // Dark Mode Colors
-  static const Color darkBackgroundMain = Color(0xFF000000);
-  static const Color darkBackgroundCard = Color(0xFF000000);
-  static const Color darkTextColor = Color(0xFFf1f1f1);
-  static const Color darkTextColorLight = Color(0xFFb0b0b0);
-  static const Color darkBorderColor = Color(0xFF1E1E1E);
-  static const Color darkGlassBackground = Color(0x33FFFFFF);
-  static const Color darkGlassBorder = Color(0x26FFFFFF);
+  static const Color darkBackgroundMain = Color(0xFF0F0F1A); // Warm dark
+  static const Color darkBackgroundCard = Color(0xFF1A1A2E); // Card
+  static const Color darkTextColor = Color(0xFFF5E6C8); // Warm cream
+  static const Color darkTextColorLight = Color(0xFFB8A88A); // Muted gold-grey
+  static const Color darkBorderColor = Color(0xFF2A2A3E); // Subtle dark border
+  static const Color darkGlassBackground = Color(0x33D4AF37); // Gold-tinted glass (20%)
+  static const Color darkGlassBorder = Color(0x26D4AF37); // Gold-tinted border (15%)
 
   // Light Mode Colors
   static const Color lightBackgroundMain = Colors.white;
@@ -50,8 +50,8 @@ class ThemeConfig {
   static const Color lightTextColorLight = Color(0xFF6F7B8A);
   static const Color lightTextColorDark = Color(0xFF263238);
   static const Color lightBorderColor = Color(0xFFE0E0E0);
-  static const Color lightGlassBackground = Color(0x66FFFFFF);
-  static const Color lightGlassBorder = Color(0x4DFFFFFF);
+  static const Color lightGlassBackground = Color(0x66D4AF37); // Gold-tinted glass (40%)
+  static const Color lightGlassBorder = Color(0x80D4AF37); // Gold-tinted border (50%)
 
   // Status Colors (same for both themes)
   static const Color successColor = Color(0xFF4caf50);

--- a/lib/config/theme_extensions.dart
+++ b/lib/config/theme_extensions.dart
@@ -96,27 +96,27 @@ class AppColorsTheme extends ThemeExtension<AppColorsTheme> {
   final Color glassBorder;
 
   static const AppColorsTheme dark = AppColorsTheme(
-    primary: Color(0xFFa777e3),
-    secondary: Color(0xFF6e8efb),
-    accent: Color(0xFF00c58e),
-    backgroundMain: Color(0xFF181a20),
-    backgroundCard: Color(0xFF23243a),
+    primary: Color(0xFFD4AF37), // Pistis Gold
+    secondary: Color(0xFFE8C547), // Warm Amber Gold
+    accent: Color(0xFFC9A227), // Deep Gold
+    backgroundMain: Color(0xFF0F0F1A), // Warm dark
+    backgroundCard: Color(0xFF1A1A2E), // Card
     backgroundLight: Color(0xFFf5f5f5),
-    textColor: Color(0xFFf1f1f1),
-    textColorLight: Color(0xFFb0b0b0),
+    textColor: Color(0xFFF5E6C8), // Warm cream
+    textColorLight: Color(0xFFB8A88A), // Muted gold-grey
     textColorDark: Color(0xFF2c3e50),
     success: Color(0xFF4caf50),
     warning: Color(0xFFffa726),
     danger: Color(0xFFff5252),
     info: Color(0xFF2196f3),
-    glassBackground: Color(0x33FFFFFF),
-    glassBorder: Color(0x4DFFFFFF),
+    glassBackground: Color(0x33D4AF37), // Gold-tinted glass (20%)
+    glassBorder: Color(0x26D4AF37), // Gold-tinted border (15%)
   );
 
   static const AppColorsTheme light = AppColorsTheme(
-    primary: Color(0xFFa777e3),
-    secondary: Color(0xFF6e8efb),
-    accent: Color(0xFF00c58e),
+    primary: Color(0xFFD4AF37), // Pistis Gold
+    secondary: Color(0xFFE8C547), // Warm Amber Gold
+    accent: Color(0xFFC9A227), // Deep Gold
     backgroundMain: Colors.white,
     backgroundCard: Color(0xFFF1F2F4),
     backgroundLight: Color(0xFFf5f5f5),
@@ -127,8 +127,8 @@ class AppColorsTheme extends ThemeExtension<AppColorsTheme> {
     warning: Color(0xFFF57C00),
     danger: Color(0xFFD32F2F),
     info: Color(0xFF1976D2),
-    glassBackground: Color(0x66FFFFFF),
-    glassBorder: Color(0x80FFFFFF),
+    glassBackground: Color(0x66D4AF37), // Gold-tinted glass (40%)
+    glassBorder: Color(0x80D4AF37), // Gold-tinted border (50%)
   );
 
   @override

--- a/lib/screens/home/home_layout.dart
+++ b/lib/screens/home/home_layout.dart
@@ -75,6 +75,7 @@ class _ChatPaneState extends State<_ChatPane> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _ensureChannelExists();
+      _autoConnectRuntime();
     });
   }
 
@@ -86,6 +87,20 @@ class _ChatPaneState extends State<_ChatPane> {
       }
     } catch (_) {
       // StreamingChatService not registered on this platform (web).
+    }
+  }
+
+  /// Auto-connect: if the backend is configured but not connected,
+  /// trigger a connection test so the user sees "Runtime channel ready"
+  /// instead of "No Agent Connected" on first launch.
+  void _autoConnectRuntime() {
+    try {
+      final cm = context.read<ConnectionManagerService>();
+      if (cm.currentBackend != null && !cm.isConnected) {
+        cm.testConnection();
+      }
+    } catch (_) {
+      // ConnectionManagerService not registered on this platform.
     }
   }
 

--- a/lib/services/connection_manager_service.dart
+++ b/lib/services/connection_manager_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:cloudtolocalllm/config/app_config.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -260,6 +261,12 @@ class ConnectionManagerService extends ChangeNotifier {
     if (_currentBackend == null && _autoDetectOnInitialize) {
       await _autoDetectRuntime();
     }
+
+    // Auto-connect: if backend is configured but not connected, test now
+    if (_currentBackend != null && !_isConnected) {
+      _log.info('Backend configured but not connected — auto-testing connection');
+      await testConnection();
+    }
   }
 
   /// Probe for available agent runtimes in order of preference.
@@ -288,11 +295,19 @@ class ConnectionManagerService extends ChangeNotifier {
 
     // 2. Try Hermes HTTP gateway
     try {
-      final httpClient = HermesStreamingService();
+      // Read API key from settings (SharedPreferences + .env fallback)
+      final settings = _settingsPreferenceService;
+      String? apiKey;
+      if (settings != null) {
+        apiKey = await settings.getHermesApiKey();
+      }
+
+      final httpClient = HermesStreamingService(apiKey: apiKey);
       await httpClient.establishConnection();
       if (httpClient.connection.isActive) {
         _log.info('Auto-detected Hermes HTTP gateway at :8642');
         _currentBackend = BackendType.hermes;
+        _configuredHermesApiKey = apiKey;
         _activeRuntimeClient = _createHermesRuntimeClient();
         notifyListeners();
         return;
@@ -582,8 +597,18 @@ class ConnectionManagerService extends ChangeNotifier {
   }
 
   HermesRuntimeClient _createHermesRuntimeClient() {
+    // Ensure the URL has a port — SharedPreferences can lose the port
+    // when the app overwrites the cached prefs on startup.
+    String url = _configuredHermesUrl ?? 'http://127.0.0.1:8642';
+    if (!url.contains(':8642') && !url.contains(':1234')) {
+      // URL is missing the port — fall back to default
+      debugPrint(
+          '[ConnectionManager] Hermes URL missing port, falling back to default: $url');
+      url = AppConfig.defaultHermesUrl;
+    }
+
     return HermesRuntimeClient(
-      baseUrl: _configuredHermesUrl ?? 'http://127.0.0.1:8642',
+      baseUrl: url,
       apiKey: _configuredHermesApiKey,
     );
   }

--- a/lib/services/onboarding/setup_wizard_service.dart
+++ b/lib/services/onboarding/setup_wizard_service.dart
@@ -233,7 +233,32 @@ class SetupWizardService extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final providers = await _discovery.scanForAgentRuntimes();
+      var providers = await _discovery.scanForAgentRuntimes();
+
+      // Fallback: if discovery returns empty, try a direct health check
+      // against the default Hermes URL. This catches cases where the
+      // discovery scan timed out or missed the running Hermes instance.
+      if (providers.isEmpty) {
+        debugPrint(
+            '[SetupWizard] No providers discovered, trying direct health check...');
+        final result =
+            await _discovery.testConnection(AppConfig.defaultHermesUrl);
+        if (result.isConnected) {
+          debugPrint(
+              '[SetupWizard] Direct health check succeeded — adding Hermes as discovered');
+          providers = [
+            ProviderInfo(
+              id: 'hermes_fallback',
+              type: ProviderType.hermes,
+              name: 'Hermes Agent',
+              url: AppConfig.defaultHermesUrl,
+              isLocal: true,
+              isAvailable: true,
+              role: ProviderRole.agentRuntime,
+            ),
+          ];
+        }
+      }
 
       final selectedRuntime = _selectPreferredRuntime(providers);
 
@@ -558,6 +583,12 @@ class SetupWizardService extends ChangeNotifier {
         await settings.setHermesEnabled(true);
         await settings.setHermesUrl(runtimeUrl);
         await settings.setActiveBackend(BackendType.hermes);
+
+        // Persist the API key — try SharedPreferences first, then .env fallback
+        var apiKey = await settings.getHermesApiKey();
+        if (apiKey != null && apiKey.isNotEmpty) {
+          await settings.setHermesApiKey(apiKey);
+        }
         break;
       case ProviderType.openclaw:
         await settings.setHermesEnabled(false);

--- a/lib/services/provider_discovery_service.dart
+++ b/lib/services/provider_discovery_service.dart
@@ -11,7 +11,7 @@ import 'package:cloudtolocalllm/services/settings_preference_service.dart';
 /// Discovers agent runtimes and optional support model providers.
 
 class ProviderDiscoveryService {
-  static const Duration _scanTimeout = Duration(seconds: 3);
+  static const Duration _scanTimeout = Duration(seconds: 10);
 
   /// Scan for all known endpoint types on the network.
   ///
@@ -154,7 +154,20 @@ class ProviderDiscoveryService {
       final response = await http.get(healthUrl).timeout(_scanTimeout);
 
       if (response.statusCode == 200) {
-        final models = await _fetchOpenAICompatibleModels(baseUrl);
+        // Read API key from SharedPreferences, fallback to .env file
+        var apiKey = await settings.getHermesApiKey();
+        apiKey ??= await _discoverHermesApiKeyFromEnv();
+
+        // Fetch models — Hermes is discovered even if model fetch fails
+        // (health check success is enough to report the runtime as available)
+        List<String> models = const [];
+        try {
+          models = await _fetchOpenAICompatibleModels(baseUrl, apiKey: apiKey);
+        } catch (e) {
+          debugPrint(
+              '[ProviderDiscovery] Model fetch failed for Hermes (non-fatal): $e');
+        }
+
         debugPrint('[ProviderDiscovery] Found Hermes Agent at $baseUrl');
         return ProviderInfo(
           id: 'hermes_discovered',
@@ -170,6 +183,42 @@ class ProviderDiscoveryService {
       }
     } catch (e) {
       debugPrint('[ProviderDiscovery] Hermes Agent not available: $e');
+    }
+    return null;
+  }
+
+  /// Try to discover the Hermes API server key from the .env file.
+  /// Searches common locations on Windows/Linux/macOS.
+  Future<String?> _discoverHermesApiKeyFromEnv() async {
+    if (kIsWeb) return null;
+
+    final envPaths = <String>[
+      '${Platform.environment['HERMES_HOME'] ?? ''}/.env',
+      '${Platform.environment['LOCALAPPDATA'] ?? ''}/hermes/.env',
+      '${Platform.environment['HOME'] ?? ''}/.hermes/.env',
+      '${Platform.environment['USERPROFILE'] ?? ''}/.hermes/.env',
+    ];
+
+    for (final path in envPaths) {
+      if (path.isEmpty) continue;
+      final file = File(path);
+      if (!await file.exists()) continue;
+      try {
+        final contents = await file.readAsString();
+        for (final line in contents.split('\n')) {
+          final trimmed = line.trim();
+          if (trimmed.startsWith('API_SERVER_KEY=')) {
+            final key = trimmed.substring('API_SERVER_KEY='.length).trim();
+            if (key.isNotEmpty) {
+              debugPrint(
+                  '[ProviderDiscovery] Found API_SERVER_KEY in $path');
+              return key;
+            }
+          }
+        }
+      } catch (e) {
+        debugPrint('[ProviderDiscovery] Error reading $path: $e');
+      }
     }
     return null;
   }
@@ -339,11 +388,21 @@ class ProviderDiscoveryService {
     return ips;
   }
 
-  Future<List<String>> _fetchOpenAICompatibleModels(String baseUrl) async {
+  Future<List<String>> _fetchOpenAICompatibleModels(
+    String baseUrl, {
+    String? apiKey,
+  }) async {
     try {
+      final url = Uri.parse('$baseUrl/v1/models');
+      final headers = <String, String>{};
+      if (apiKey != null && apiKey.isNotEmpty) {
+        headers['Authorization'] = 'Bearer $apiKey';
+      }
       final response =
-          await http.get(Uri.parse('$baseUrl/v1/models')).timeout(_scanTimeout);
+          await http.get(url, headers: headers).timeout(_scanTimeout);
       if (response.statusCode != 200) {
+        debugPrint(
+            '[ProviderDiscovery] /v1/models returned ${response.statusCode} from $baseUrl');
         return const [];
       }
       final data = jsonDecode(response.body);

--- a/lib/services/settings_preference_service.dart
+++ b/lib/services/settings_preference_service.dart
@@ -1,4 +1,6 @@
+import 'dart:io';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/foundation.dart';
 
 enum BackendType { openclaw, hermes }
 
@@ -359,7 +361,51 @@ class SettingsPreferenceService {
   /// Hermes API key (optional — Hermes doesn't require auth by default)
   Future<String?> getHermesApiKey() async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_hermesApiKeyKey);
+    final key = prefs.getString(_hermesApiKeyKey);
+    if (key != null && key.isNotEmpty) {
+      return key;
+    }
+
+    // Fallback: try to discover API_SERVER_KEY from Hermes .env file
+    return _discoverApiKeyFromEnv();
+  }
+
+  /// Try to discover the Hermes API server key from the .env file.
+  /// Searches common locations on Windows/Linux/macOS.
+  Future<String?> _discoverApiKeyFromEnv() async {
+    if (kIsWeb) return null;
+
+    final envPaths = <String>[
+      '${Platform.environment['HERMES_HOME'] ?? ''}/.env',
+      '${Platform.environment['LOCALAPPDATA'] ?? ''}/hermes/.env',
+      '${Platform.environment['HOME'] ?? ''}/.hermes/.env',
+      '${Platform.environment['USERPROFILE'] ?? ''}/.hermes/.env',
+    ];
+
+    for (final path in envPaths) {
+      if (path.isEmpty) continue;
+      final file = File(path);
+      if (!await file.exists()) continue;
+      try {
+        final contents = await file.readAsString();
+        for (final line in contents.split('\n')) {
+          final trimmed = line.trim();
+          if (trimmed.startsWith('API_SERVER_KEY=')) {
+            final key = trimmed.substring('API_SERVER_KEY='.length).trim();
+            if (key.isNotEmpty) {
+              debugPrint(
+                  '[SettingsPreference] Found API_SERVER_KEY in $path');
+              // Cache it so we don't read the file every time
+              await setHermesApiKey(key);
+              return key;
+            }
+          }
+        }
+      } catch (e) {
+        debugPrint('[SettingsPreference] Error reading $path: $e');
+      }
+    }
+    return null;
   }
 
   Future<void> setHermesApiKey(String? value) async {


### PR DESCRIPTION
## Fixes #502

The setup wizard had 6 documented auto-detection fixes (from the 2026-06-28 reference) that were never applied to the codebase. All 10 root causes now fixed.

## Files Changed (5 files, +184/-8)

| File | Fixes |
|------|-------|
| `provider_discovery_service.dart` | Timeout 3s→10s, `_scanHermes()` reads API key from prefs + `.env` fallback, Hermes reported as discovered even if model fetch fails (non-fatal), `_fetchOpenAICompatibleModels()` accepts `apiKey` param with `Authorization: Bearer` header, added `_discoverHermesApiKeyFromEnv()` |
| `settings_preference_service.dart` | `getHermesApiKey()` falls back to `API_SERVER_KEY` from Hermes `.env` file (checks `HERMES_HOME`, `LOCALAPPDATA`, `HOME/.hermes`, `USERPROFILE/.hermes`), caches found key |
| `connection_manager_service.dart` | `_autoDetectRuntime()` passes API key to `HermesStreamingService`, `initialize()` auto-calls `testConnection()` when backend configured but not connected, `_createHermesRuntimeClient()` falls back to `defaultHermesUrl` when URL is missing port |
| `setup_wizard_service.dart` | `scanForProviders()` has fallback direct health check against `AppConfig.defaultHermesUrl` when discovery returns empty, `_persistRuntimeSelection()` now persists API key |
| `home_layout.dart` | `initState()` calls `_autoConnectRuntime()` which triggers `testConnection()` when backend configured but not connected |

## Verification

Tested locally with `flutter run -d windows`. Logs confirm:
- `[ProviderDiscovery] Found Hermes Agent at http://127.0.0.1:8642`
- App shows 'Runtime channel ready' with 'Message Hermes...' chat input
- Auto-connect works on startup (no 'No Agent Connected' state)
- Discovery finds Hermes + Ollama + LM Studio consistently across scan cycles